### PR TITLE
Remove default hiddenField option for checkboxes

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -104,7 +104,6 @@ class FormHelper extends BaseForm
                 unset($options['class']);
             }
         }
-        $options['hiddenField'] = false;
 
         return parent::checkbox($fieldName, $options);
     }


### PR DESCRIPTION
Setting the hiddenField to false by default does not show unchecked checkboxes on request data
